### PR TITLE
Correct invalid dunder method name to `__post_init__`

### DIFF
--- a/babelcode/data_types/result_types.py
+++ b/babelcode/data_types/result_types.py
@@ -306,7 +306,7 @@ class QuestionResult:
   results: Dict[str, List[int]] = dataclasses.field(
       default_factory=lambda: collections.defaultdict(list))
 
-  def __post__init__(self) -> None:
+  def __post_init__(self) -> None:
     """Remove reserved attrs from those tracked."""
     for k in RESERVED_ATTRIBUTES:
       if k in self.tracked_attributes:


### PR DESCRIPTION
I believe what the author meant here is `__post_init__`, not `__post__init__`, as per the Python's documentation:
https://docs.python.org/3.9/library/dataclasses.html#post-init-processing.

What it implies is that this method was probably never executed. An alternative to this commit would be removal of the method.